### PR TITLE
Fix: GitHub Actions deployment missing Worker secrets configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,18 @@ jobs:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         command: deploy --env production
+        secrets: |
+          DISCORD_TOKEN
+          DISCORD_PUBLIC_KEY
+          DISCORD_APPLICATION_ID
+          REGISTER_COMMAND_REQUEST_CHANNEL_ID
+          REGISTER_COMMAND_RESPONSE_CHANNEL_ID
+      env:
+        DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+        DISCORD_PUBLIC_KEY: ${{ secrets.DISCORD_PUBLIC_KEY }}
+        DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}
+        REGISTER_COMMAND_REQUEST_CHANNEL_ID: ${{ secrets.REGISTER_COMMAND_REQUEST_CHANNEL_ID }}
+        REGISTER_COMMAND_RESPONSE_CHANNEL_ID: ${{ secrets.REGISTER_COMMAND_RESPONSE_CHANNEL_ID }}
         
     - name: Wrangler Production Validation
       if: success()


### PR DESCRIPTION
## Summary
- Adds Worker secrets configuration to GitHub Actions deploy workflow
- Ensures automated deployments include all necessary Discord bot secrets
- Fixes Discord channel validation failures after GitHub Actions deployments
- Makes automated deployments consistent with manual deployments

## Problem
GitHub Actions deployments were not configuring Worker secrets, causing Discord `/register` command to fail with channel validation errors. The deploy workflow only configured Cloudflare API authentication but did not pass any Worker environment secrets.

## Root Cause Analysis
The `wrangler-action` in `.github/workflows/deploy.yml` was missing the `secrets:` configuration:

**Before (broken):**
```yaml
- name: Deploy to Cloudflare Workers
  uses: cloudflare/wrangler-action@v3
  with:
    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
    command: deploy --env production
    # Missing: secrets configuration
```

This caused:
- Manual deployments: ✅ Worked (preserved existing secrets)
- GitHub Actions deployments: ❌ Failed (no Worker secrets configured)

## Solution
Added comprehensive Worker secrets configuration to the wrangler-action:

**After (fixed):**
```yaml
- name: Deploy to Cloudflare Workers
  uses: cloudflare/wrangler-action@v3
  with:
    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
    command: deploy --env production
    secrets:  < /dev/null | 
      DISCORD_TOKEN
      DISCORD_PUBLIC_KEY
      DISCORD_APPLICATION_ID
      REGISTER_COMMAND_REQUEST_CHANNEL_ID
      REGISTER_COMMAND_RESPONSE_CHANNEL_ID
  env:
    DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
    DISCORD_PUBLIC_KEY: ${{ secrets.DISCORD_PUBLIC_KEY }}
    DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}
    REGISTER_COMMAND_REQUEST_CHANNEL_ID: ${{ secrets.REGISTER_COMMAND_REQUEST_CHANNEL_ID }}
    REGISTER_COMMAND_RESPONSE_CHANNEL_ID: ${{ secrets.REGISTER_COMMAND_RESPONSE_CHANNEL_ID }}
```

## Test Plan
- [x] Verify workflow syntax is correct
- [x] Confirm all GitHub repository secrets exist
- [x] Validate commit passes quality checks
- [ ] Test Discord `/register` command works after GitHub Actions deployment
- [ ] Verify channel validation succeeds in production
- [ ] Confirm automated deployments no longer break functionality

## Files Changed
- `.github/workflows/deploy.yml` - Added Worker secrets configuration

## Dependencies
- All required GitHub repository secrets are already configured
- Discord bot secrets already used in validation step

## Expected Result
After this fix, GitHub Actions deployments will properly configure Worker secrets, making the Discord `/register` command work correctly from the designated channel (`1243372169908588554`) without requiring manual intervention.

Resolves #55